### PR TITLE
fix: allow console.assert

### DIFF
--- a/src/style-parts/common.json
+++ b/src/style-parts/common.json
@@ -15,9 +15,10 @@
       "error",
       {
         "allow": [
-          "warn",
           "error",
-          "info"
+          "warn",
+          "info",
+          "assert"
         ]
       }
     ],


### PR DESCRIPTION
It can be used permantently in the code for emit warnings.