### PR TITLE
fix: disable ban-ts-ignore

### DIFF
--- a/spec/ts-recommended/ban-ts-ignore.pass.ts
+++ b/spec/ts-recommended/ban-ts-ignore.pass.ts
@@ -1,0 +1,4 @@
+function dummy(x: number) { return x }
+
+// @ts-ignore
+dummy(...[1])

--- a/src/style-parts/ts-common.json
+++ b/src/style-parts/ts-common.json
@@ -8,6 +8,7 @@
     "ecmaVersion": 2019
   },
   "rules": {
+    "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/member-delimiter-style": "off",
     "harmony/ts-member-delimiter-style": [


### PR DESCRIPTION
It should not be banned by default.
`@ts-ignore` is created for a reason.
We should be able to use it reasonably (and sparsingly, of course).