### PR TITLE
fix: relax explicit-module-boundary-types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
     "typescriptreact"
   ],
   "prettier.eslintIntegration": true,
-  "prettier.requireConfig": true
+  "prettier.requireConfig": true,
+  "cSpell.words": [
+    "singleline"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ You also need to change your language version approprately:
 
 ![language version](2018-03-06-16-14-48.png)
 
-
 ## Contribute
 
 ```sh

--- a/spec/ts-recommended/explicit-function-return-type.pass.ts
+++ b/spec/ts-recommended/explicit-function-return-type.pass.ts
@@ -1,1 +1,2 @@
 export const x = (): void => { }
+export const noReturnTypeOkToo = () => { }

--- a/spec/ts-recommended/explicit-module-boundary-types.pass.ts
+++ b/spec/ts-recommended/explicit-module-boundary-types.pass.ts
@@ -1,2 +1,3 @@
 export const sig: () => void = () => { }
 export const high = () => (): void => { }
+export const noReturnTypeOkToo = () => { }

--- a/src/style-parts/ts-common.json
+++ b/src/style-parts/ts-common.json
@@ -9,12 +9,7 @@
   },
   "rules": {
     "@typescript-eslint/ban-ts-comment": "off",
-    "@typescript-eslint/explicit-module-boundary-types": [
-      "warn",
-      {
-        "allowArgumentsExplicitlyTypedAsAny": true
-      }
-    ],
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/member-delimiter-style": "off",
     "harmony/ts-member-delimiter-style": [


### PR DESCRIPTION
While the intention is good,
`explicit-module-boundary-types` is useful only for limited cases.
Especially when you get to some advance type which relies on type inference.

Engineers should have tests to protect themselves from breaking type changes in the tests.

Recommending using type checking utilities in `type-plus`