### PR TITLE
feat: disable no-unsafe-argument and member-access

### DIFF
--- a/spec/ts-recommended-requiring-type-checking/.eslintrc
+++ b/spec/ts-recommended-requiring-type-checking/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "extends": "../../lib/ts-recommended-requiring-type-checking",
-  "parserOptions": {
-    "project": "../../tsconfig.json"
-  },
-  "env": {
-    "node": true
-  }
- }

--- a/spec/ts-recommended-type-check/.eslintrc
+++ b/spec/ts-recommended-type-check/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "../../lib/ts-recommended-type-check",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "env": {
+    "node": true
+  }
+ }

--- a/spec/ts-recommended-type-check/ts-no-unsafe-argument.pass.ts
+++ b/spec/ts-recommended-type-check/ts-no-unsafe-argument.pass.ts
@@ -1,0 +1,8 @@
+export function foo(...args: any[]) {
+  // it's ok as we explicity specify that.
+  boo(...args)
+}
+
+function boo(...args: any[]) {
+  console.info(args)
+}

--- a/spec/ts-recommended-type-check/ts-no-unsafe-member-access.pass.ts
+++ b/spec/ts-recommended-type-check/ts-no-unsafe-member-access.pass.ts
@@ -1,0 +1,4 @@
+export function foo() {
+  const x: any = {}
+  console.info(x['abc'])
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import latest from './latest.json'
 import recommended from './recommended.json'
 import { rules } from './rules'
 import tsPrettier from './ts-prettier.json'
-import tsRecommendedTypeCheck2 from './ts-recommended-type-check.json'
-import tsRecommendedTypeCheck from './ts-recommended-requiring-type-checking.json'
+import tsRecommendedTypeCheck from './ts-recommended-type-check.json'
+import tsRecommendedTypeCheck2 from './ts-recommended-requiring-type-checking.json'
 import tsRecommended from './ts-recommended.json'
 
 export = {
@@ -15,8 +15,8 @@ export = {
     latest,
     recommended,
     'ts-prettier': tsPrettier,
-    'ts-recommended-type-check': tsRecommendedTypeCheck2,
-    'ts-recommended-requiring-type-checking': tsRecommendedTypeCheck,
+    'ts-recommended-type-check': tsRecommendedTypeCheck,
+    'ts-recommended-requiring-type-checking': tsRecommendedTypeCheck2,
     'ts-recommended': tsRecommended,
   },
   rules

--- a/src/ts-recommended-requiring-type-checking.json
+++ b/src/ts-recommended-requiring-type-checking.json
@@ -5,5 +5,9 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "./style-parts/ts-common"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off"
+  }
 }

--- a/src/ts-recommended-type-check.json
+++ b/src/ts-recommended-type-check.json
@@ -5,5 +5,9 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "./style-parts/ts-common"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "./tsconfig.lib.json"
+  "extends": "./tsconfig.lib.json",
+  "include": [
+    "spec",
+    "src",
+    "src/style-parts/*.json",
+    "typings"
+  ]
 }


### PR DESCRIPTION
When we assert the type as any,
it should be considered as explicit choice we make and doing argument spread and member access should be allowed.

`no-unsafe-call` and `no-unsafe-assigment` is ok as they could spread `any` to other places.