### PR TITLE
fix: disable indent rule

### DIFF
--- a/src/style-parts/ts-common.json
+++ b/src/style-parts/ts-common.json
@@ -11,10 +11,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/indent": [
-      "error",
-      2
-    ],
+    "@typescript-eslint/indent": "off",
     "@typescript-eslint/member-delimiter-style": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",


### PR DESCRIPTION
Due to the issues about indent,
the problem it causes outweight the benefits it brings.

We are disabling the indent rule completely, except for prettier.

If you are not using prettier,
please use `editorconfig` to make sure your code are indented "correctly".

https://github.com/typescript-eslint/typescript-eslint/issues/1824