### PR TITLE
fix: parser should be regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "verify": "yarn build && yarn lint && yarn test"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^5.23.0"
+    "@typescript-eslint/experimental-utils": "^5.23.0",
+    "@typescript-eslint/parser": "^5.23.0"
   },
   "devDependencies": {
     "@commitlint/cli": "16.3.0",
     "@commitlint/config-conventional": "16.2.4",
     "@types/node": "17.0.23",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
-    "@typescript-eslint/parser": "^5.23.0",
     "ansi-colors": "4.1.1",
     "eslint": "8.15.0",
     "eslint-config-prettier": "^8.0.0",
@@ -66,7 +66,6 @@
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
     "eslint": ">=8.4.0",
     "eslint-config-prettier": "^8.0.0"
   },


### PR DESCRIPTION
> However, if your shareable config depends on a third-party parser or another shareable config,
you can specify these packages as dependencies.

https://eslint.org/docs/developer-guide/shareable-configs#publishing-a-shareable-config